### PR TITLE
feat: aup system with user signing tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ seamlessly connect.
 - Adverts
 - Printer Consumable Levels
 - Student Password Resets
+- AUP Acceptance
 
 ## Getting Started
 

--- a/app/lib/config.server.ts
+++ b/app/lib/config.server.ts
@@ -116,6 +116,10 @@ export const ConfigDefaults = {
   aupCache: {
     value: '',
     description: 'The MDX cache of the acceptable use policy.'
+  },
+  aupRequired: {
+    value: 'no',
+    description: 'yes/no is the AUP required.'
   }
 } as const
 
@@ -127,7 +131,8 @@ export const ConfigurableValues = omit(ConfigDefaults, [
   'headerStrip',
   'headerStripCache',
   'aup',
-  'aupCache'
+  'aupCache',
+  'aupRequired'
 ])
 
 export type PrinterConfig = {

--- a/app/lib/config.server.ts
+++ b/app/lib/config.server.ts
@@ -108,6 +108,14 @@ export const ConfigDefaults = {
   snowScript: {
     value: 'no',
     description: 'yes/no enable snow on the start page.'
+  },
+  aup: {
+    value: '',
+    description: 'The Acceptable use Policy'
+  },
+  aupCache: {
+    value: '',
+    description: 'The MDX cache of the acceptable use policy.'
   }
 } as const
 
@@ -117,7 +125,9 @@ export const ConfigurableValues = omit(ConfigDefaults, [
   'brandDark',
   'brandLight',
   'headerStrip',
-  'headerStripCache'
+  'headerStripCache',
+  'aup',
+  'aupCache'
 ])
 
 export type PrinterConfig = {

--- a/app/lib/config.server.ts
+++ b/app/lib/config.server.ts
@@ -120,6 +120,10 @@ export const ConfigDefaults = {
   aupRequired: {
     value: 'no',
     description: 'yes/no is the AUP required.'
+  },
+  aupGroup: {
+    value: '',
+    description: 'The group to remove users from after they sign.'
   }
 } as const
 
@@ -132,7 +136,8 @@ export const ConfigurableValues = omit(ConfigDefaults, [
   'headerStripCache',
   'aup',
   'aupCache',
-  'aupRequired'
+  'aupRequired',
+  'aupGroup'
 ])
 
 export type PrinterConfig = {

--- a/app/lib/ldap.server.ts
+++ b/app/lib/ldap.server.ts
@@ -1,0 +1,72 @@
+import * as ldap from 'ldapjs'
+
+export const createClient = (
+  dc: string,
+  adminDN: string,
+  adminPassword: string
+): Promise<
+  {error: string; client: undefined} | {client: ldap.Client; error: undefined}
+> => {
+  return new Promise((resolve, reject) => {
+    const client = ldap.createClient({
+      url: `ldaps://${dc}`,
+      tlsOptions: {rejectUnauthorized: false}
+    })
+    client.bind(adminDN, adminPassword, err => {
+      if (err) {
+        resolve({error: 'Unable to connect to the domain', client: undefined})
+        return
+      }
+
+      resolve({client, error: undefined})
+    })
+  })
+}
+
+export const findUserDN = async (
+  client: ldap.Client,
+  username: string,
+  ou: string
+): Promise<{error: string; dn: undefined} | {error: undefined; dn: string}> => {
+  return new Promise((resolve, reject) => {
+    client.search(
+      ou,
+      {
+        filter: `(sAMAccountName=${username})`,
+        scope: 'sub'
+      },
+      (err, res) => {
+        if (err) {
+          resolve({error: `Unable to find user ${username}`, dn: undefined})
+          return
+        }
+        let entries = 0
+
+        res.on('searchEntry', entry => {
+          entries += 1
+          resolve({dn: entry.dn.toString(), error: undefined})
+        })
+
+        res.on('end', result => {
+          if (entries === 0) {
+            resolve({error: `Unable to find user ${username}`, dn: undefined})
+            client.unbind()
+          }
+        })
+      }
+    )
+  })
+}
+
+export const createChange = (change: ldap.Change) => {
+  return new ldap.Change(change)
+}
+
+export const createAttribute = (type: string, values: any) => {
+  return new ldap.Attribute({
+    type,
+    // @types/ldapjs expects `vals` vs the new correct property of `values`
+    // @ts-expect-error
+    values
+  })
+}

--- a/app/lib/user.server.ts
+++ b/app/lib/user.server.ts
@@ -44,7 +44,8 @@ export const getUserFromUPN = async (upn: string) => {
       createdAt: new Date(),
       updatedAt: new Date(),
       formGroup: '',
-      manual: true
+      manual: true,
+      aupAccepted: true
     }
 
     return defaultUser

--- a/app/routes/admin._index.tsx
+++ b/app/routes/admin._index.tsx
@@ -209,6 +209,11 @@ const AdminIndex = () => {
                 return <li key={i}>{scope}</li>
               })}
             </ul>
+            {data.user.type === 'STUDENT'
+              ? data.user.aupAccepted
+                ? 'Has signed the AUP'
+                : 'Has not signed the AUP'
+              : ''}
           </div>
         ) : (
           ''

--- a/app/routes/admin._index.tsx
+++ b/app/routes/admin._index.tsx
@@ -144,6 +144,12 @@ const AdminIndex = () => {
             Info Messages
           </a>
           <a
+            href="/admin/aup"
+            className="text-center border border-brand-dark rounded"
+          >
+            Acceptable Use Policy
+          </a>
+          <a
             href="/admin/logs"
             className="text-center border border-brand-dark rounded"
           >

--- a/app/routes/admin.aup.tsx
+++ b/app/routes/admin.aup.tsx
@@ -1,0 +1,156 @@
+import {
+  type LoaderArgs,
+  type ActionArgs,
+  json,
+  redirect,
+  type HeadersArgs,
+  type LinksFunction
+} from '@remix-run/node'
+import {useLoaderData} from '@remix-run/react'
+import {invariant} from '@arcath/utils'
+import CodeEditor from '@uiw/react-textarea-code-editor'
+import {useState} from 'react'
+
+import {getUPNFromHeaders, getUserFromUPN} from '~/lib/user.server'
+import {createTimings, combineServerTimingHeaders} from '~/utils/timings.server'
+import {getConfigValue, setConfigValue} from '~/lib/config.server'
+import {getPrisma} from '~/lib/prisma'
+
+import {log} from '~/log.server'
+
+import {
+  fieldsetClasses,
+  labelClasses,
+  inputClasses,
+  buttonClasses,
+  labelSpanClasses,
+  labelInfoClasses
+} from '~/lib/classes'
+
+import styles from '@uiw/react-textarea-code-editor/dist.css'
+import {compileMDX} from '~/lib/mdx.server'
+
+export const links: LinksFunction = () => {
+  return [{rel: 'stylesheet', href: styles}]
+}
+
+export const loader = async ({request}: LoaderArgs) => {
+  const {time, getHeader} = createTimings()
+
+  const user = await time('getUser', 'Get User from header', () =>
+    getUserFromUPN(getUPNFromHeaders(request))
+  )
+
+  if (!user || !user.admin) {
+    throw new Response('Access Denied', {status: 403})
+  }
+
+  const aup = await getConfigValue('aup')
+
+  const prisma = getPrisma()
+
+  const [usersCount, aupAcceptedCount] = await time(
+    'getAupCounts',
+    'Get AUP User Counts',
+    async () => {
+      return [
+        await prisma.user.count({where: {type: 'STUDENT'}}),
+        await prisma.user.count({where: {aupAccepted: true, type: 'STUDENT'}})
+      ]
+    }
+  )
+
+  return json(
+    {aup, user, usersCount, aupAcceptedCount},
+    {
+      headers: {'Server-Timing': getHeader()}
+    }
+  )
+}
+
+export const action = async ({request}: ActionArgs) => {
+  const {time, getHeader} = createTimings()
+
+  const user = await time('getUser', 'Get User from header', () =>
+    getUserFromUPN(getUPNFromHeaders(request))
+  )
+
+  if (!user || !user.admin) {
+    throw new Response('Access Denied', {status: 403})
+  }
+
+  const formData = await request.formData()
+
+  const body = formData.get('body') as string | undefined
+
+  invariant(body)
+
+  const aupCache = await compileMDX(body)
+
+  await setConfigValue('aup', body)
+  await setConfigValue('aupCache', aupCache)
+
+  return redirect('/admin', {
+    headers: {'Server-Timing': getHeader()}
+  })
+}
+
+export const headers = ({loaderHeaders, actionHeaders}: HeadersArgs) => {
+  return combineServerTimingHeaders(loaderHeaders, actionHeaders)
+}
+
+const AdminAUP = () => {
+  const {aup, usersCount, aupAcceptedCount} = useLoaderData<typeof loader>()
+
+  const [body, setBody] = useState(aup)
+
+  return (
+    <div className="mt-4 shadow-xl bg-white w-1/2 m-auto rounded-xl p-2">
+      <h1 className="text-3xl">Acceptable Use Policy</h1>
+      <div className="bg-blue-100 rounded w-full h-2 flex overflow-hidden my-4">
+        <div
+          className="bg-blue-400"
+          style={{width: `${(aupAcceptedCount / usersCount) * 100}`}}
+        />
+      </div>
+      <div className="grid grid-cols-3">
+        <div className="text-center">
+          <b>{aupAcceptedCount}</b>
+          <br />
+          Users Accepted AUP
+        </div>
+        <div className="text-center">
+          <b>{usersCount - aupAcceptedCount}</b>
+          <br />
+          Users still to accept AUP
+        </div>
+        <div className="text-center">
+          <b>{usersCount}</b>
+          <br />
+          Users
+        </div>
+      </div>
+      <form method="POST">
+        <fieldset className={fieldsetClasses()}>
+          <label className={labelClasses()}>
+            <span className={labelSpanClasses()}>AUP</span>
+            <CodeEditor
+              name="body"
+              value={body}
+              className={inputClasses('min-h-[55vh]')}
+              language="jsx"
+              onChange={e => {
+                setBody(e.target.value)
+              }}
+            />
+          </label>
+        </fieldset>
+        <div className={labelClasses()}>
+          <button className={buttonClasses()}>Update AUP</button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default AdminAUP

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -31,6 +31,7 @@ const AdminPage = () => {
           <a href="/admin/assets">Assets</a>
           <a href="/admin/doodles">Doodles</a>
           <a href="/admin/messages">Info Messages</a>
+          <a href="/admin/aup">Acceptable Use Policy</a>
           <a href="/admin/logs">Logs</a>
           <a href="/admin/debug">Debug Headers</a>
         </div>

--- a/app/routes/aup.tsx
+++ b/app/routes/aup.tsx
@@ -1,0 +1,104 @@
+import {
+  type LoaderArgs,
+  type HeadersArgs,
+  type ActionArgs,
+  json,
+  redirect
+} from '@remix-run/node'
+import {useLoaderData} from '@remix-run/react'
+import {useState} from 'react'
+
+import {getUPNFromHeaders, getUserFromUPN} from '~/lib/user.server'
+import {getMDXComponent} from '~/lib/mdx'
+
+import {getConfigValue} from '~/lib/config.server'
+
+import {createTimings, combineServerTimingHeaders} from '~/utils/timings.server'
+import {buttonClasses, inputClasses, labelSpanClasses} from '~/lib/classes'
+import {getPrisma} from '~/lib/prisma'
+
+export const loader = async ({request}: LoaderArgs) => {
+  const {time, getHeader} = createTimings()
+  const user = await time('getUser', 'Get User from header', () =>
+    getUserFromUPN(getUPNFromHeaders(request))
+  )
+
+  const aup = await getConfigValue('aupCache')
+
+  return json(
+    {user, aup},
+    {
+      headers: {'Server-Timing': getHeader()}
+    }
+  )
+}
+
+export const action = async ({request}: ActionArgs) => {
+  const {time, getHeader} = createTimings()
+  const user = await time('getUser', 'Get User from header', () =>
+    getUserFromUPN(getUPNFromHeaders(request))
+  )
+
+  const prisma = getPrisma()
+
+  await time('updateUser', 'Update User', () =>
+    prisma.user.update({where: {id: user.id}, data: {aupAccepted: true}})
+  )
+
+  return redirect('/start', {
+    headers: {'Server-Timing': getHeader()}
+  })
+}
+
+export const headers = ({loaderHeaders, actionHeaders}: HeadersArgs) => {
+  return combineServerTimingHeaders(loaderHeaders, actionHeaders)
+}
+
+const AcceptableUsePolicy = () => {
+  const {user, aup} = useLoaderData<typeof loader>()
+  const [signature, setSignature] = useState('')
+
+  const AUP = getMDXComponent(aup, {currentUser: user.username})
+
+  return (
+    <div>
+      {user.aupAccepted ? (
+        ''
+      ) : (
+        <div className="w-3/4 prose bg-brand-dark text-white rounded-xl shadow-xl m-auto mt-12 p-2">
+          Before you can use the school network please read and accept the
+          acceptable use policy.
+        </div>
+      )}
+      <div className="w-3/4 prose bg-white rounded-xl shadow-xl m-auto mt-12 p-2">
+        <AUP />
+      </div>
+      <div className="w-3/4 bg-white rounded-xl shadow-xl m-auto mt-12 p-2 grid grid-cols-4 gap-2">
+        <h3 className={labelSpanClasses()}>Sign</h3>
+        <input
+          className={inputClasses()}
+          value={signature}
+          onChange={e => {
+            setSignature(e.target.value)
+          }}
+          placeholder="Enter your full name as listed below."
+        />
+        <form method="POST">
+          <button
+            className={buttonClasses('bg-green-300', [
+              'col-start-4',
+              'disabled:bg-green-100 disabled:shadow-none',
+              'w-full'
+            ])}
+            disabled={signature !== user.name}
+          >
+            Sign
+          </button>
+        </form>
+        <div className="col-start-2 px-2 text-grey-400">{user.name}</div>
+      </div>
+    </div>
+  )
+}
+
+export default AcceptableUsePolicy

--- a/app/routes/aup.tsx
+++ b/app/routes/aup.tsx
@@ -73,7 +73,7 @@ export const action = async ({request}: ActionArgs) => {
       modification: createAttribute('member', dn)
     })
 
-    const result = await new Promise((resolve, reject) => {
+    await new Promise((resolve, reject) => {
       client.modify(groupDN, [change], err => {
         resolve(err)
       })

--- a/app/routes/start.tsx
+++ b/app/routes/start.tsx
@@ -12,7 +12,7 @@ import {Button} from '~/lib/components/boxes/button'
 import {Intro} from '~/lib/components/boxes/intro'
 import {Doodle} from '~/lib/components/doodle'
 
-import {getConfigValues} from '~/lib/config.server'
+import {getConfigValue, getConfigValues} from '~/lib/config.server'
 import {getUPNFromHeaders, getUserFromUPN} from '~/lib/user.server'
 import {createTimings} from '~/utils/timings.server'
 
@@ -27,7 +27,9 @@ export const loader = async ({request}: LoaderArgs) => {
     getUserFromUPN(getUPNFromHeaders(request))
   )
 
-  if (user.type === 'STUDENT' && !user.aupAccepted) {
+  const aupRequired = await getConfigValue('aupRequired')
+
+  if (aupRequired === 'yes' && user.type === 'STUDENT' && !user.aupAccepted) {
     return redirect('/aup')
   }
 

--- a/app/routes/start.tsx
+++ b/app/routes/start.tsx
@@ -1,7 +1,11 @@
-import {type LoaderArgs, type HeadersArgs} from '@remix-run/node'
+import {
+  type LoaderArgs,
+  type HeadersArgs,
+  redirect,
+  json
+} from '@remix-run/node'
 import {useEffect} from 'react'
 import {diffArray, pick, increment} from '@arcath/utils'
-import {json} from '@remix-run/node'
 import {useLoaderData, useCatch, useSearchParams} from '@remix-run/react'
 
 import {Button} from '~/lib/components/boxes/button'
@@ -22,6 +26,11 @@ export const loader = async ({request}: LoaderArgs) => {
   const user = await time('getUser', 'Get User from header', () =>
     getUserFromUPN(getUPNFromHeaders(request))
   )
+
+  if (user.type === 'STUDENT' && !user.aupAccepted) {
+    return redirect('/aup')
+  }
+
   const prisma = getPrisma()
 
   const {shortcuts, hasOverflow, scopes} = await time(

--- a/docs/docs/features/acceptable-use-policy.md
+++ b/docs/docs/features/acceptable-use-policy.md
@@ -17,6 +17,7 @@ you to set:
   off).
 - Yes/No should all users have their AUP acceptance reset on save.
 - The DN of the group to **remove** users from.
+- The username of a user to reset thier AUP acceptance.
 
 ### Group DN
 

--- a/docs/docs/features/acceptable-use-policy.md
+++ b/docs/docs/features/acceptable-use-policy.md
@@ -1,0 +1,33 @@
+# Acceptable Use Policy
+
+Start Screen has a system for enforcing users must sign an AUP before using it.
+Couple this with a filtering system that sends members of a group to this page
+and you can put a hard requirement on using the internet.
+
+It **only applies to students** as staff should be agreeing to policies during
+their induction etc...
+
+## Configuration
+
+Through the admin panl you can access the _Acceptable Use Policy_ which allows
+you to set:
+
+- The body of the policy as [MDX](/guides/working-with-mdx).
+- Yes/No is the SUP required to view the start screen. (Turns the feature on and
+  off).
+- Yes/No should all users have their AUP acceptance reset on save.
+- The DN of the group to **remove** users from.
+
+### Group DN
+
+If supplied the password resetting user set in config will be used to remove the
+current user from the group. If this is left blank nothing happens.
+
+If you reset the AUP acceptance in Start Screen it _does not_ add them back to
+the group.
+
+## Signing
+
+Users are directed to `/aup` which has the full AUP on it and a box for them to
+enter their name as defined in teh database (it is shown to the user). Once they
+enter their name they will be able to click the sign button.

--- a/docs/docs/features/index.md
+++ b/docs/docs/features/index.md
@@ -1,5 +1,9 @@
 # Features
 
+## [Acceptable Use Policy](/features/acceptable-use-policy)
+
+Force users to read and sign an acceptable use policy.
+
 ## [Doodles](/features/doodles)
 
 Date-scoped MDX Components to brighten up the start page.

--- a/prisma/migrations/20230713101549_add_aup_accepted_to_user/migration.sql
+++ b/prisma/migrations/20230713101549_add_aup_accepted_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "aupAccepted" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model User {
   classesTaught    Class[]
   classMemberships ClassMembership[]
   shortcuts        Shortcut[]
+  aupAccepted      Boolean           @default(false)
 }
 
 model Class {


### PR DESCRIPTION
Does this PR cause start screen changes?: To a point, if users have not accepted the AUP it will redirect them to the AUP page.

## Checklist

- [x] Documentation updated.
- [x] Change group membership on sign.
- [x] Option to set `aupAccepted` to false for all users one AUP change.
- [x] Add AUP status to user lookup.
- [x] Ability to ask a single user to resign

## Summary

Adds a system to redirect students that have not accepted the AUP to the AUP screen. Users can then _sign_ the AUP.

Closes #17
